### PR TITLE
Fix variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following is a full configuration example for *build.gradle*:
         createRepoArgs = "--arg1 --arg2"                            // Extra arguments for the createrepo command
         s3AccessKey = "ACCESS-KEY"                                  // Overrides the default AWS provider chain
         s3SecretKey = "SECRET-KEY"                                  // Overrides the default AWS provider chain 
-        allowCreateRepository = false                               // Default. Creates repo metadata if it doesn't exist 
+        allowCreateRepo = false                               // Default. Creates repo metadata if it doesn't exist 
         forcePublish = false                                         // Default. Overwrites already-publish packages
         skipUpdate = false                                          // Default. Skips updating the repository metadata
         skipUpload = false                                          // Default. Skips the upload to S3


### PR DESCRIPTION
In the README, you have the variable `allowCreateRepository`, but in the code it's [spelled differently](https://github.com/bazaarvoice/s3repo-gradle-plugin/blob/master/src/main/java/com/bazaarvoice/gradle/plugin/S3RepoExtension.java#L12).

Setting `allowCreateRepository = true` will result in the following error:
```
* What went wrong:
A problem occurred evaluating root project 'pkg_node_exporter'.
> Could not set unknown property 'allowCreateRepository' for object of type com.bazaarvoice.gradle.plugin.S3RepoExtension.
```